### PR TITLE
Fix compatibility for .NET Framework 4.8

### DIFF
--- a/AppUpdater.cs
+++ b/AppUpdater.cs
@@ -105,7 +105,7 @@ namespace SCLOCUA
                 var response = await client.GetAsync(installerUrl);
                 response.EnsureSuccessStatusCode();
 
-                await using (var fs = new FileStream(tempInstallerPath, FileMode.Create, FileAccess.Write, FileShare.None, 8192, true))
+                using (var fs = new FileStream(tempInstallerPath, FileMode.Create, FileAccess.Write, FileShare.None, 8192, true))
                 {
                     await response.Content.CopyToAsync(fs);
                 }

--- a/Form1.cs
+++ b/Form1.cs
@@ -226,7 +226,10 @@ namespace SCLOCUA
                     Directory.CreateDirectory(directoryPath);
                 }
 
-                await File.WriteAllBytesAsync(filePath, fileData);
+                using (var fs = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None, 8192, true))
+                {
+                    await fs.WriteAsync(fileData, 0, fileData.Length);
+                }
 
             }
             catch (HttpRequestException ex)

--- a/killFeed.cs
+++ b/killFeed.cs
@@ -259,8 +259,21 @@ namespace SCLOCUA
             newLabel.MouseEnter += (s, e) => Cursor.Hide();
             newLabel.MouseLeave += (s, e) => Cursor.Show();
 
-            var toRemove = this.Controls.OfType<Label>().Where(lbl => lbl.Bottom < 0).ToList();
-            toRemove.ForEach(lbl => { this.Controls.Remove(lbl); lbl.Dispose(); });
+            var toRemove = new System.Collections.Generic.List<Label>();
+            foreach (Control control in this.Controls)
+            {
+                var lbl = control as Label;
+                if (lbl != null && lbl.Bottom < 0)
+                {
+                    toRemove.Add(lbl);
+                }
+            }
+
+            foreach (var lbl in toRemove)
+            {
+                this.Controls.Remove(lbl);
+                lbl.Dispose();
+            }
         }
 
         private void PlayKillSound()
@@ -316,9 +329,11 @@ namespace SCLOCUA
             int lineHeight = (int)(20 * scaleFactor);
             int y = this.ClientSize.Height - lineHeight;
 
-            foreach (Control c in this.Controls.Cast<Control>().Reverse())
+            for (int i = this.Controls.Count - 1; i >= 0; i--)
             {
-                if (c is Label lbl)
+                Control c = this.Controls[i];
+                Label lbl = c as Label;
+                if (lbl != null)
                 {
                     lbl.Font = new Font("Consolas", 10 * scaleFactor);
                     lbl.Top = y;


### PR DESCRIPTION
## Summary
- Replace C# 8 features with .NET Framework 4.8 friendly alternatives
- Remove LINQ dependency in killFeed control management
- Use FileStream-based async writes instead of unavailable APIs

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68953e2411348325957291c58c2f81db