### PR TITLE
Fix Program.cs for C# 7.3 compatibility and include AppConfig

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -10,78 +10,84 @@ namespace SCLOCUA
         [STAThread]
         static void Main()
         {
-            using var mutex = new Mutex(true, "{EA6A248E-8F44-4C82-92F6-03F6A055E637}", out bool created);
-            if (!created)
-                return;
-
-            Application.EnableVisualStyles();
-            Application.SetCompatibleTextRenderingDefault(false);
-
-            Form1 mainForm = new Form1();
-            using (NotifyIcon notifyIcon = new NotifyIcon())
+            using (var mutex = new Mutex(true, "{EA6A248E-8F44-4C82-92F6-03F6A055E637}", out bool created))
             {
-                notifyIcon.Icon = mainForm.Icon;
-                notifyIcon.Text = "Українізатор Star Citizen";
-                notifyIcon.DoubleClick += (sender, e) =>
-                {
-                    mainForm.Show();
-                    mainForm.WindowState = FormWindowState.Normal;
-                };
+                if (!created)
+                    return;
 
-                ContextMenu contextMenu = new ContextMenu();
-                MenuItem startupMenuItem = new MenuItem("Запускати при старті");
-                bool isStartupEnabled = IsStartupEnabled();
-                startupMenuItem.Checked = isStartupEnabled;
-                startupMenuItem.Click += (sender, e) =>
-                {
-                    isStartupEnabled = !isStartupEnabled;
-                    SetStartup(isStartupEnabled);
-                    startupMenuItem.Checked = isStartupEnabled;
-                };
-                contextMenu.MenuItems.Add("Відкрити", (sender, e) =>
-                {
-                    mainForm.Show();
-                    mainForm.WindowState = FormWindowState.Normal;
-                });
-                contextMenu.MenuItems.Add(startupMenuItem);
-                contextMenu.MenuItems.Add("Вихід", (sender, e) =>
-                {
-                    notifyIcon.Visible = false;
-                    Application.Exit();
-                });
-                notifyIcon.ContextMenu = contextMenu;
+                Application.EnableVisualStyles();
+                Application.SetCompatibleTextRenderingDefault(false);
 
-                Application.ApplicationExit += (s, e) => notifyIcon.Visible = false;
-
-                mainForm.Resize += (sender, e) =>
+                Form1 mainForm = new Form1();
+                using (NotifyIcon notifyIcon = new NotifyIcon())
                 {
-                    if (mainForm.WindowState == FormWindowState.Minimized)
+                    notifyIcon.Icon = mainForm.Icon;
+                    notifyIcon.Text = "Українізатор Star Citizen";
+                    notifyIcon.DoubleClick += (sender, e) =>
                     {
-                        mainForm.Hide();
-                        notifyIcon.Visible = true;
-                    }
-                };
+                        mainForm.Show();
+                        mainForm.WindowState = FormWindowState.Normal;
+                    };
 
-                Application.Run(mainForm);
+                    ContextMenu contextMenu = new ContextMenu();
+                    MenuItem startupMenuItem = new MenuItem("Запускати при старті");
+                    bool isStartupEnabled = IsStartupEnabled();
+                    startupMenuItem.Checked = isStartupEnabled;
+                    startupMenuItem.Click += (sender, e) =>
+                    {
+                        isStartupEnabled = !isStartupEnabled;
+                        SetStartup(isStartupEnabled);
+                        startupMenuItem.Checked = isStartupEnabled;
+                    };
+                    contextMenu.MenuItems.Add("Відкрити", (sender, e) =>
+                    {
+                        mainForm.Show();
+                        mainForm.WindowState = FormWindowState.Normal;
+                    });
+                    contextMenu.MenuItems.Add(startupMenuItem);
+                    contextMenu.MenuItems.Add("Вихід", (sender, e) =>
+                    {
+                        notifyIcon.Visible = false;
+                        Application.Exit();
+                    });
+                    notifyIcon.ContextMenu = contextMenu;
+
+                    Application.ApplicationExit += (s, e) => notifyIcon.Visible = false;
+
+                    mainForm.Resize += (sender, e) =>
+                    {
+                        if (mainForm.WindowState == FormWindowState.Minimized)
+                        {
+                            mainForm.Hide();
+                            notifyIcon.Visible = true;
+                        }
+                    };
+
+                    Application.Run(mainForm);
+                }
+                mutex.ReleaseMutex();
             }
-            mutex.ReleaseMutex();
         }
 
         static bool IsStartupEnabled()
         {
-            using RegistryKey key = Registry.CurrentUser.OpenSubKey(AppConfig.RegistryKeyPath, true);
-            return key != null && key.GetValue(AppConfig.AppName) != null;
+            using (RegistryKey key = Registry.CurrentUser.OpenSubKey(AppConfig.RegistryKeyPath, true))
+            {
+                return key != null && key.GetValue(AppConfig.AppName) != null;
+            }
         }
 
         static void SetStartup(bool enable)
         {
-            using RegistryKey key = Registry.CurrentUser.OpenSubKey(AppConfig.RegistryKeyPath, true);
-            if (key == null) return;
+            using (RegistryKey key = Registry.CurrentUser.OpenSubKey(AppConfig.RegistryKeyPath, true))
+            {
+                if (key == null) return;
 
-            if (enable)
-                key.SetValue(AppConfig.AppName, Application.ExecutablePath);
-            else
-                key.DeleteValue(AppConfig.AppName, false);
+                if (enable)
+                    key.SetValue(AppConfig.AppName, Application.ExecutablePath);
+                else
+                    key.DeleteValue(AppConfig.AppName, false);
+            }
         }
     }
 }

--- a/SCLOCUA.csproj
+++ b/SCLOCUA.csproj
@@ -85,6 +85,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AntiAFK.cs" />
+    <Compile Include="AppConfig.cs" />
     <Compile Include="AppUpdater.cs" />
     <Compile Include="HttpClientService.cs" />
     <Compile Include="Form1.cs">


### PR DESCRIPTION
## Summary
- Replace C# 8 `using` declarations in Program.cs with classic `using (...)` blocks for C# 7.3/.NET 4.8 compatibility
- Include AppConfig.cs in the project so configuration constants are available

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_6895685b470c8325a0b334fd824dcc8e