### PR TITLE
Stop and dispose timer on form close

### DIFF
--- a/HangarTimerOverlay.cs
+++ b/HangarTimerOverlay.cs
@@ -108,11 +108,17 @@ namespace SCLOCUA
 
             // Update timer
             _updateTimer = new Timer { Interval = 1000 };
-            _updateTimer.Tick += (s, e) => UpdateDisplay();
+            _updateTimer.Tick += UpdateTimerTick;
 
-            Load += async (s, e) => await InitializeAsync();
-            FormClosed += (s, e) => UnregisterHotKeys();
+            Load += HangarTimerOverlay_Load;
         }
+
+        private async void HangarTimerOverlay_Load(object sender, EventArgs e)
+        {
+            await InitializeAsync();
+        }
+
+        private void UpdateTimerTick(object sender, EventArgs e) => UpdateDisplay();
 
         /// <summary>
         /// Fetches the global cycle start time from the remote JavaScript file
@@ -303,6 +309,17 @@ namespace SCLOCUA
             base.WndProc(ref m);
         }
         #endregion
+
+        protected override void OnFormClosed(FormClosedEventArgs e)
+        {
+            _updateTimer.Stop();
+            _updateTimer.Tick -= UpdateTimerTick;
+            _updateTimer.Dispose();
+            Load -= HangarTimerOverlay_Load;
+            _opacityTip.Dispose();
+            UnregisterHotKeys();
+            base.OnFormClosed(e);
+        }
 
         protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
         {


### PR DESCRIPTION
## Summary
- stop and dispose the Hangar timer's update timer when the overlay closes
- unregister timer and form load event handlers to avoid memory leaks

## Testing
- `msbuild SCLOCUA.sln` *(fails: command not found)*
- `dotnet build SCLOCUA.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689617995d508325bf213984c6b0942e