### PR TITLE
Dispose hangar overlay on form closing

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -472,6 +472,9 @@ namespace SCLOCUA
         private void Form1_FormClosing(object sender, FormClosingEventArgs e)
         {
             _antiAFK.Dispose();
+            _hangarOverlay?.Close();
+            _hangarOverlay?.Dispose();
+            _hangarOverlay = null;
         }
 
         private void buttonExHangar_Click(object sender, EventArgs e)


### PR DESCRIPTION
## Summary
- Clean up hangar overlay when main form closes

## Testing
- `dotnet build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689620f7dc3083258bd1331c132c13c6