### PR TITLE
Use custom lamp indicator control for hangar overlay

### DIFF
--- a/HangarTimerOverlay.cs
+++ b/HangarTimerOverlay.cs
@@ -26,8 +26,7 @@ namespace SCLOCUA
 
         private readonly Label _statusLabel;
         private readonly Label _phaseTimerLabel;
-        private readonly Label[] _lampLabels = new Label[5];
-        private readonly Label[] _lampTimerLabels = new Label[5];
+        private readonly LampIndicator[] _lamps = new LampIndicator[5];
         private readonly Timer _updateTimer;
         private readonly ToolTip _opacityTip = new ToolTip();
 
@@ -69,43 +68,41 @@ namespace SCLOCUA
             Controls.Add(_phaseTimerLabel);
 
             // Lamps panel
-            var panel = new TableLayoutPanel
+            var panel = new Panel
             {
                 Dock = DockStyle.Fill,
-                ColumnCount = 5,
-                RowCount = 2,
                 BackColor = Color.Transparent
             };
-            panel.ColumnStyles.Clear();
-            for (int i = 0; i < 5; i++)
-                panel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 20F));
-            panel.RowStyles.Add(new RowStyle(SizeType.Percent, 60F));
-            panel.RowStyles.Add(new RowStyle(SizeType.Percent, 40F));
+            Controls.Add(panel);
 
-            var lampFont = new Font("Segoe UI Symbol", 32, FontStyle.Regular);
-            var timerFont = new Font("Consolas", 12, FontStyle.Bold);
+            const int lampDiameter = 40;
+            const int lampSpacing = 20;
+            const int lampHeight = 60;
+
             for (int i = 0; i < 5; i++)
             {
-                _lampLabels[i] = new Label
+                var lamp = new LampIndicator
                 {
-                    Text = "●",
-                    Dock = DockStyle.Fill,
-                    TextAlign = ContentAlignment.MiddleCenter,
-                    Font = lampFont,
-                    ForeColor = Color.Black
+                    Size = new Size(lampDiameter, lampHeight),
+                    LampColor = Color.Black
                 };
-                panel.Controls.Add(_lampLabels[i], i, 0);
-
-                _lampTimerLabels[i] = new Label
-                {
-                    Dock = DockStyle.Fill,
-                    TextAlign = ContentAlignment.TopCenter,
-                    Font = timerFont,
-                    ForeColor = Color.White
-                };
-                panel.Controls.Add(_lampTimerLabels[i], i, 1);
+                _lamps[i] = lamp;
+                panel.Controls.Add(lamp);
             }
-            Controls.Add(panel);
+
+            void LayoutLamps()
+            {
+                int totalWidth = _lamps.Length * lampDiameter + (_lamps.Length - 1) * lampSpacing;
+                int startX = (panel.ClientSize.Width - totalWidth) / 2;
+                int y = (panel.ClientSize.Height - lampHeight) / 2;
+                for (int i = 0; i < _lamps.Length; i++)
+                {
+                    _lamps[i].Location = new Point(startX + i * (lampDiameter + lampSpacing), y);
+                }
+            }
+
+            panel.Resize += (s, e) => LayoutLamps();
+            LayoutLamps();
 
             // Update timer
             _updateTimer = new Timer { Interval = 1000 };
@@ -259,9 +256,11 @@ namespace SCLOCUA
 
             for (int i = 0; i < 5; i++)
             {
-                _lampLabels[i].ForeColor = lights[i] == "red" ? Color.Red :
-                                           lights[i] == "green" ? Color.Lime : Color.Black;
-                _lampTimerLabels[i].Text = i == minIndex ? ledTimers[i] : string.Empty;
+                _lamps[i].LampColor = lights[i] == "red" ? Color.Red :
+                                       lights[i] == "green" ? Color.Lime : Color.Black;
+                _lamps[i].TimerText = ledTimers[i];
+                _lamps[i].ShowTimer = i == minIndex;
+                _lamps[i].Invalidate();
             }
         }
 

--- a/LampIndicator.cs
+++ b/LampIndicator.cs
@@ -1,0 +1,65 @@
+using System.Drawing;
+using System.Windows.Forms;
+using System.Drawing.Drawing2D;
+
+namespace SCLOCUA
+{
+    public class LampIndicator : Control
+    {
+        private Color _lampColor = Color.Black;
+        private string _timerText = string.Empty;
+        private bool _showTimer;
+
+        public Color LampColor
+        {
+            get => _lampColor;
+            set { _lampColor = value; Invalidate(); }
+        }
+
+        public string TimerText
+        {
+            get => _timerText;
+            set { _timerText = value; Invalidate(); }
+        }
+
+        public bool ShowTimer
+        {
+            get => _showTimer;
+            set { _showTimer = value; Invalidate(); }
+        }
+
+        public LampIndicator()
+        {
+            SetStyle(ControlStyles.AllPaintingInWmPaint | ControlStyles.UserPaint |
+                     ControlStyles.OptimizedDoubleBuffer, true);
+            ForeColor = Color.White;
+            Size = new Size(40, 60);
+        }
+
+        protected override void OnPaint(PaintEventArgs e)
+        {
+            base.OnPaint(e);
+            var g = e.Graphics;
+            g.SmoothingMode = SmoothingMode.AntiAlias;
+
+            int diameter = 40; // circle diameter
+            int circleX = (Width - diameter) / 2;
+            int circleY = 0;
+            using (var brush = new SolidBrush(_lampColor))
+            {
+                g.FillEllipse(brush, circleX, circleY, diameter, diameter);
+            }
+
+            if (_showTimer && !string.IsNullOrEmpty(_timerText))
+            {
+                using (var format = new StringFormat { Alignment = StringAlignment.Center })
+                using (var font = new Font("Consolas", 10, FontStyle.Bold))
+                using (var brush = new SolidBrush(ForeColor))
+                {
+                    g.DrawString(_timerText, font, brush,
+                                 new RectangleF(0, diameter, Width, Height - diameter), format);
+                }
+            }
+        }
+    }
+}

--- a/SCLOCUA.csproj
+++ b/SCLOCUA.csproj
@@ -88,6 +88,7 @@
     <Compile Include="AppConfig.cs" />
     <Compile Include="AppUpdater.cs" />
     <Compile Include="HttpClientService.cs" />
+    <Compile Include="LampIndicator.cs" />
     <Compile Include="Form1.cs">
       <SubType>Form</SubType>
     </Compile>


### PR DESCRIPTION
## Summary
- add custom `LampIndicator` control for drawing colored lamp and timer text
- replace label-based lamp layout with `LampIndicator` instances centered on overlay
- wire up overlay logic to update lamp color and timer via new control

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689623846a648325adf3f58e86547d30