### PR TITLE
Centralize configuration constants

### DIFF
--- a/AppUpdater.cs
+++ b/AppUpdater.cs
@@ -12,7 +12,6 @@ namespace SCLOCUA
 {
     internal class AppUpdater
     {
-        private const string GitHubApiUrl = "https://api.github.com/repos/Vova-Bob/SCLoc_App/releases/latest";
 
         public async Task CheckForUpdatesAsync()
         {
@@ -76,7 +75,7 @@ namespace SCLOCUA
             try
             {
                 var client = HttpClientService.Client;
-                var response = await client.GetStringAsync(GitHubApiUrl);
+                var response = await client.GetStringAsync(AppConfig.GitHubApiUrl);
 
                 Console.WriteLine("Отримано дані про реліз: " + response);
 

--- a/WikiForm.cs
+++ b/WikiForm.cs
@@ -11,7 +11,6 @@ namespace SCLOCUA
     public partial class WikiForm : Form
     {
         private Dictionary<string, string> wikiDictionary = new Dictionary<string, string>();
-        private const string WikiUrl = "https://api.github.com/repos/Vova-Bob/SC_localization_UA/contents/wiki.ini";
         private HttpClient client;
         private int _autoCompleteIndex = 0; // Індекс поточного терміна
         private List<string> autoCompleteKeys = new List<string>(); // Список всіх термінів для автодоповнення
@@ -30,7 +29,7 @@ namespace SCLOCUA
         private async void WikiForm_Load(object sender, EventArgs e)
         {
             button1.Enabled = false;
-            string wikiText = await DownloadWikiTextAsync(WikiUrl);
+            string wikiText = await DownloadWikiTextAsync(AppConfig.WikiUrl);
 
             if (!string.IsNullOrEmpty(wikiText))
             {


### PR DESCRIPTION
## Summary
- remove duplicate constant values from `Form1`, `AppUpdater`, and `WikiForm`
- reference configuration constants via `AppConfig`

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6897b20f374083258773f31855495a1f