### PR TITLE
Add xUnit test project

### DIFF
--- a/ExecutiveHangarOverlay/Stubs.cs
+++ b/ExecutiveHangarOverlay/Stubs.cs
@@ -1,4 +1,4 @@
-#if !FEATURE_OVERLAY
+﻿#if !FEATURE_OVERLAY
 // Minimal stubs so Program.cs compiles without removing features.
 // Keep API surface tiny; replace with real implementations later.
 using System;
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+#pragma warning disable CS0067
 
 namespace ExecutiveHangarOverlay
 {
@@ -82,4 +83,5 @@ namespace ExecutiveHangarOverlay
         public void Dispose() { }
     }
 }
+#pragma warning restore CS0067
 #endif

--- a/Form1.cs
+++ b/Form1.cs
@@ -101,7 +101,7 @@ namespace SCLOCUA
         }
 
         // ---- Select game folder ----
-        private void SelectFolderButtonClick(object sender, EventArgs e)
+        private void SelectFolderButtonClick(object? sender, EventArgs e)
         {
             using (var folderDialog = new FolderBrowserDialog())
             {
@@ -127,7 +127,7 @@ namespace SCLOCUA
         }
 
         // ---- Install/Update localization ----
-        private async void UpdateLocalizationButtonClick(object sender, EventArgs e)
+        private async void UpdateLocalizationButtonClick(object? sender, EventArgs e)
         {
             if (string.IsNullOrWhiteSpace(selectedFolderPath) || !Directory.Exists(selectedFolderPath))
             {
@@ -304,7 +304,7 @@ namespace SCLOCUA
         }
 
         // ---- Delete localization files ----
-        private async void DeleteFilesButtonClick(object sender, EventArgs e)
+        private async void DeleteFilesButtonClick(object? sender, EventArgs e)
         {
             if (string.IsNullOrWhiteSpace(selectedFolderPath)) return;
 
@@ -358,7 +358,7 @@ namespace SCLOCUA
             else control.Click += OpenLink;
         }
 
-        private void OpenLink(object sender, EventArgs e)
+        private void OpenLink(object? sender, EventArgs e)
         {
             if (sender is Control ctrl && ctrl.Tag is string url) OpenUrl(url);
         }
@@ -423,7 +423,7 @@ namespace SCLOCUA
         }
 
         // ---- Form events ----
-        private void Form1_Load(object sender, EventArgs e)
+        private void Form1_Load(object? sender, EventArgs e)
         {
             if (!string.IsNullOrWhiteSpace(selectedFolderPath))
             {
@@ -438,13 +438,13 @@ namespace SCLOCUA
             UpdateKillFeedButtonUi(overlayForm != null && overlayForm.Visible && !overlayForm.IsDisposed);
         }
 
-        private void pictureBox2_Click(object sender, EventArgs e)
+        private void pictureBox2_Click(object? sender, EventArgs e)
         {
             OpenUrl("https://send.monobank.ua/jar/44HXkQkorg");
         }
 
         // Wiki toggle
-        private void buttonWiki_Click(object sender, EventArgs e)
+        private void buttonWiki_Click(object? sender, EventArgs e)
         {
             if (wikiForm == null || wikiForm.IsDisposed)
             {
@@ -465,7 +465,7 @@ namespace SCLOCUA
         }
 
         // Clear shaders cache
-        private void buttonClearCache_Click(object sender, EventArgs e)
+        private void buttonClearCache_Click(object? sender, EventArgs e)
         {
             try
             {
@@ -497,12 +497,12 @@ namespace SCLOCUA
         }
 
         // Anti-AFK toggle
-        private void ButtonAntiAFK_Click(object sender, EventArgs e)
+        private void ButtonAntiAFK_Click(object? sender, EventArgs e)
         {
             _antiAFK.ToggleAntiAFK(toolStripStatusLabel1);
         }
 
-        private void Form1_FormClosing(object sender, FormClosingEventArgs e)
+        private void Form1_FormClosing(object? sender, FormClosingEventArgs e)
         {
             _antiAFK.Dispose();
             // Close overlay if still open (avoid zombie handle)
@@ -510,7 +510,7 @@ namespace SCLOCUA
         }
 
         // ---- KillFeed (overlay) ----
-        private void buttonkillfeed_Click(object sender, EventArgs e)
+        private void buttonkillfeed_Click(object? sender, EventArgs e)
         {
             if (overlayForm == null || overlayForm.IsDisposed)
             {

--- a/README.md
+++ b/README.md
@@ -15,3 +15,12 @@
 
 ## Скріншоти
 ![Головне вікно](img/sclocua.jpg)
+
+## Running tests
+
+```bash
+dotnet restore
+dotnet build -c Release
+dotnet test -c Release
+```
+

--- a/SCLOCUA.sln
+++ b/SCLOCUA.sln
@@ -1,25 +1,30 @@
-﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.8.34511.84
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SCLOCUA", "SCLOCUA.csproj", "{E998D500-9A0D-4D1C-ABEE-5B2D310E8353}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SCLoc_App.Tests", "SCLoc_App.Tests\\SCLoc_App.Tests.csproj", "{272FD9A4-9E15-4EAE-8061-986539146914}"
+EndProject
 Global
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{E998D500-9A0D-4D1C-ABEE-5B2D310E8353}.Debug|Any CPU.ActiveCfg = Release|Any CPU
-		{E998D500-9A0D-4D1C-ABEE-5B2D310E8353}.Debug|Any CPU.Build.0 = Release|Any CPU
-		{E998D500-9A0D-4D1C-ABEE-5B2D310E8353}.Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{E998D500-9A0D-4D1C-ABEE-5B2D310E8353}.Release|Any CPU.Build.0 = Debug|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {C2EEED5A-0893-4957-95DE-4FA398CC28E6}
-	EndGlobalSection
+        GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                Debug|Any CPU = Debug|Any CPU
+                Release|Any CPU = Release|Any CPU
+        EndGlobalSection
+        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {E998D500-9A0D-4D1C-ABEE-5B2D310E8353}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {E998D500-9A0D-4D1C-ABEE-5B2D310E8353}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {E998D500-9A0D-4D1C-ABEE-5B2D310E8353}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {E998D500-9A0D-4D1C-ABEE-5B2D310E8353}.Release|Any CPU.Build.0 = Release|Any CPU
+                {272FD9A4-9E15-4EAE-8061-986539146914}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {272FD9A4-9E15-4EAE-8061-986539146914}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {272FD9A4-9E15-4EAE-8061-986539146914}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {272FD9A4-9E15-4EAE-8061-986539146914}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
+        GlobalSection(SolutionProperties) = preSolution
+                HideSolutionNode = FALSE
+        EndGlobalSection
+        GlobalSection(ExtensibilityGlobals) = postSolution
+                SolutionGuid = {C2EEED5A-0893-4957-95DE-4FA398CC28E6}
+        EndGlobalSection
 EndGlobal

--- a/SCLoc_App.Tests/AppConfigTests.cs
+++ b/SCLoc_App.Tests/AppConfigTests.cs
@@ -1,0 +1,13 @@
+using Xunit;
+using SCLOCUA;
+
+namespace SCLoc_App.Tests;
+
+public class AppConfigTests
+{
+    [Fact]
+    public void LocalizationPath_IsNotEmpty()
+    {
+        Assert.False(string.IsNullOrEmpty(AppConfig.LocalizationPath));
+    }
+}

--- a/SCLoc_App.Tests/SCLoc_App.Tests.csproj
+++ b/SCLoc_App.Tests/SCLoc_App.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SCLOCUA.csproj" />
+  </ItemGroup>
+</Project>

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.406"
+    "version": "8.0.406",
+    "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
## Summary
- pin .NET SDK 8.0.406 with rollForward latestFeature
- suppress unused event warnings in overlay stubs and make Form1 handlers nullable
- mark SCLoc_App.Tests as a test project, tidy solution, and document running tests

## Testing
- `dotnet --info` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*
- `dotnet restore` *(fails: command not found)*
- `dotnet build -c Release` *(fails: command not found)*
- `dotnet test -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a08152aa08325ab28f0f08328bd0d