### PR TITLE
Add explicit application configuration initialization

### DIFF
--- a/ApplicationConfiguration.cs
+++ b/ApplicationConfiguration.cs
@@ -1,0 +1,14 @@
+using System.Windows.Forms;
+
+namespace SCLOCUA.Manual
+{
+    internal static class ApplicationConfiguration
+    {
+        public static void Initialize()
+        {
+            Application.SetHighDpiMode(HighDpiMode.PerMonitorV2);
+            Application.EnableVisualStyles();
+            Application.SetCompatibleTextRenderingDefault(false);
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using Microsoft.Win32;
 using ExecutiveHangarOverlay; // HangarOverlayForm, HotkeyMessageFilter
+using ApplicationConfiguration = SCLOCUA.Manual.ApplicationConfiguration;
 
 namespace SCLOCUA
 {


### PR DESCRIPTION
## Summary
- add `ApplicationConfiguration.Initialize()` to explicitly configure high DPI, visual styles, and text rendering
- wire `Program.cs` to use the new configuration class while keeping existing initialization call

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_689b75f9d43c83258777bd9d94569ee7