### PR TITLE
Add control anchor extension helper

### DIFF
--- a/Extensions/ControlExtensions.cs
+++ b/Extensions/ControlExtensions.cs
@@ -1,0 +1,15 @@
+using System.Windows.Forms;
+
+namespace SCLOCUA.Extensions
+{
+    public static class ControlExtensions
+    {
+        public static void AnchorIfExists(this Control? control, AnchorStyles anchor)
+        {
+            if (control != null)
+            {
+                control.Anchor = anchor;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add extension method to set Anchor on controls only if they exist

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_689b7fed894c832597c4bab9236ff17a