### PR TITLE
Improve form rendering with optimized double buffering

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -29,7 +29,10 @@ namespace SCLOCUA
 
         public Form1()
         {
+            SuspendLayout();
             InitializeComponent();
+            SetStyle(ControlStyles.OptimizedDoubleBuffer | ControlStyles.AllPaintingInWmPaint, true);
+            UpdateStyles();
 
             // Shared HttpClient from your project
             httpClient = HttpClientService.Client;
@@ -61,6 +64,8 @@ namespace SCLOCUA
 
             InitializeUI();
             InitializeEvents();
+
+            ResumeLayout();
         }
 
         // ---- Initial UI state ----

--- a/HangarOverlayForm.cs
+++ b/HangarOverlayForm.cs
@@ -68,6 +68,7 @@ namespace ExecutiveHangarOverlay
 
         public HangarOverlayForm(long cycleStartMs)
         {
+            SuspendLayout();
             _cycleStartMs = cycleStartMs;
 
             // Form setup
@@ -76,6 +77,8 @@ namespace ExecutiveHangarOverlay
             StartPosition = FormStartPosition.CenterScreen;
             TopMost = true;
             DoubleBuffered = true;
+            SetStyle(ControlStyles.OptimizedDoubleBuffer | ControlStyles.AllPaintingInWmPaint, true);
+            UpdateStyles();
             BackColor = Color.FromArgb(18, 18, 18);
             Opacity = _targetOpacity;
             ClientSize = new Size(BASE_W, BASE_H);
@@ -111,6 +114,8 @@ namespace ExecutiveHangarOverlay
             _uiTimer.Start();
 
             UpdateModel();
+
+            ResumeLayout();
         }
 
         // ===== Public API: called from Program.cs via global hotkeys =====
@@ -450,11 +455,14 @@ namespace ExecutiveHangarOverlay
 
         public InputMsDialog()
         {
+            SuspendLayout();
             Text = "Введіть час старту";
             FormBorderStyle = FormBorderStyle.FixedDialog;
             StartPosition = FormStartPosition.CenterParent;
             ClientSize = new Size(420, 170);
             MaximizeBox = MinimizeBox = false;
+            SetStyle(ControlStyles.OptimizedDoubleBuffer | ControlStyles.AllPaintingInWmPaint, true);
+            UpdateStyles();
 
             _box = new TextBox { Left = 15, Top = 15, Width = 390 };
 
@@ -466,7 +474,7 @@ namespace ExecutiveHangarOverlay
                 Height = 70,
                 AutoSize = false,
                 Text =
-    @"Приклади:
+@"Приклади:
 • 1753997899074       (UNIX мс)
 • 15:52 або 15:52:39  (сьогодні, локальний час)",
             };
@@ -479,6 +487,7 @@ namespace ExecutiveHangarOverlay
             CancelButton = cancel;
 
             _box.Text = DateTime.Now.ToString("HH:mm:ss");
+            ResumeLayout();
         }
 
         protected override void OnFormClosing(FormClosingEventArgs e)

--- a/WikiForm.cs
+++ b/WikiForm.cs
@@ -18,13 +18,17 @@ namespace SCLOCUA
 
         public WikiForm()
         {
+            SuspendLayout();
             InitializeComponent();
+            SetStyle(ControlStyles.OptimizedDoubleBuffer | ControlStyles.AllPaintingInWmPaint, true);
+            UpdateStyles();
             client = HttpClientService.Client;
             button1.Click += button1_Click;
             this.Load += WikiForm_Load;
             textBox1.KeyDown += textBox1_KeyDown;
             textBox1.MouseWheel += textBox1_MouseWheel; // Додано обробник прокручування миші для textBox1
             richTextBox1.MouseWheel += richTextBox1_MouseWheel; // Додано обробник прокручування миші для richTextBox1
+            ResumeLayout();
         }
 
         private async void WikiForm_Load(object sender, EventArgs e)

--- a/killFeed.cs
+++ b/killFeed.cs
@@ -65,11 +65,13 @@ namespace SCLOCUA
 
         public killFeed(string folderPath)
         {
+            SuspendLayout();
             InitializeComponent();
 
             // Transparent form (only bubbles are drawn by children)
             this.DoubleBuffered = true;
             this.SetStyle(ControlStyles.OptimizedDoubleBuffer | ControlStyles.AllPaintingInWmPaint, true);
+            UpdateStyles();
             Color key = Color.Lime;
             this.BackColor = key;
             this.TransparencyKey = key;
@@ -106,6 +108,8 @@ namespace SCLOCUA
 
             // Start tailing
             _ = TailAsync();
+
+            ResumeLayout();
         }
 
         // inside class killFeed


### PR DESCRIPTION
## Summary
- Enable OptimizedDoubleBuffer and AllPaintingInWmPaint for all form constructors
- Wrap constructor logic in SuspendLayout/ResumeLayout to prevent unnecessary layout work

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_689b85273a4083259d10407559c85893