### PR TITLE
Improve high DPI rendering and UI clarity

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -30,6 +30,7 @@ namespace SCLOCUA
         public Form1()
         {
             InitializeComponent();
+            UI.UiFix.Apply(this);
 
             // Shared HttpClient from your project
             httpClient = HttpClientService.Client;

--- a/Properties/Application.Designer.cs
+++ b/Properties/Application.Designer.cs
@@ -1,0 +1,20 @@
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace SCLOCUA
+{
+    /// <summary>
+    /// Specifies application-wide defaults for generated configuration.
+    /// </summary>
+    internal static partial class ApplicationConfiguration
+    {
+        // Use per-monitor DPI to avoid blurry scaling.
+        public const HighDpiMode HighDpiMode = System.Windows.Forms.HighDpiMode.PerMonitorV2;
+        // Render text with GDI+ for clarity.
+        public const bool UseCompatibleTextRenderingDefault = false;
+        // Enable themed controls.
+        public const bool EnableVisualStyles = true;
+        // Standardize default font across controls.
+        public static readonly Font DefaultFont = new("Segoe UI", 9f);
+    }
+}

--- a/Properties/app.manifest
+++ b/Properties/app.manifest
@@ -12,4 +12,9 @@
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
     </application>
   </compatibility>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </windowsSettings>
+  </application>
 </assembly>

--- a/UI/UiFix.cs
+++ b/UI/UiFix.cs
@@ -1,0 +1,59 @@
+using System.Drawing;
+using System.Reflection;
+using System.Windows.Forms;
+
+namespace SCLOCUA.UI
+{
+    /// <summary>
+    /// Applies minor runtime tweaks to improve UI clarity on high DPI displays.
+    /// </summary>
+    internal static class UiFix
+    {
+        /// <summary>
+        /// Adjusts the supplied form and its controls.
+        /// </summary>
+        public static void Apply(Form form)
+        {
+            if (form == null) return;
+
+            // Scale with monitor DPI and avoid stretched background images.
+            form.AutoScaleMode = AutoScaleMode.Dpi;
+            form.BackgroundImageLayout = ImageLayout.Zoom;
+
+            EnableDoubleBuffer(form);
+            ProcessControls(form.Controls);
+        }
+
+        // Recursively process all controls.
+        private static void ProcessControls(Control.ControlCollection controls)
+        {
+            foreach (Control ctrl in controls)
+            {
+                if (ctrl is Label lbl)
+                {
+                    // Use GDI+ rendering and transparent backgrounds for labels.
+                    lbl.UseCompatibleTextRendering = false;
+                    lbl.BackColor = Color.Transparent;
+                }
+                else if (ctrl is Button btn)
+                {
+                    // System style buttons have better contrast.
+                    btn.FlatStyle = FlatStyle.System;
+                }
+
+                EnableDoubleBuffer(ctrl);
+
+                if (ctrl.HasChildren)
+                    ProcessControls(ctrl.Controls);
+            }
+        }
+
+        // Enable DoubleBuffered via reflection for smoother redraw.
+        private static void EnableDoubleBuffer(Control control)
+        {
+            typeof(Control)
+                .GetProperty("DoubleBuffered", BindingFlags.Instance | BindingFlags.NonPublic)
+                ?.SetValue(control, true, null);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Configure application for per-monitor DPI awareness and default Segoe UI font
- Add runtime UI tweaks for clearer, double-buffered controls
- Apply UI fixes after main form initialization

## Testing
- `dotnet build` (warnings: CS8622, CS8601, CS8625, CS0067)


------
https://chatgpt.com/codex/tasks/task_e_68aa21b16ee483259130efba3e1ed7f3